### PR TITLE
:arrow_up:  Bump flask-cors version to 5.0.0 to mitigate CVE

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ email_validator
 flask~=3.0.0
 flask-assets
 flask-compress
-flask-cors~=4.0.0
+flask-cors~=5.0.0
 flask-limiter
 flask-talisman
 govuk-frontend-jinja~=2.7.0


### PR DESCRIPTION
This CVE was reported in: https://github.com/ministryofjustice/operations-engineering-example-app/security/dependabot/3 and relates to a setting we don't actually use, but is swtiched on by default.
